### PR TITLE
fixed problem with sidebar overflow

### DIFF
--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -385,7 +385,9 @@ ul#mysidebar {
 
 
 #mysidebar {
-min-width: 240px;
+  width: 100%;
+  word-wrap: break-word;
+  position: relative;
 }
 
 .nav ul li ul li a {


### PR DESCRIPTION
Hey,
There's a problem with sidebar overflow. When I set a long name the sidebar goes to the second column:

![screen shot 2015-05-12 at 9 33 04 pm](https://cloud.githubusercontent.com/assets/5272402/7594013/a29f2816-f8e6-11e4-98af-32e480147a2b.png)

Here's how it looks now:
![screen shot 2015-05-12 at 9 33 35 pm](https://cloud.githubusercontent.com/assets/5272402/7594024/abe567e6-f8e6-11e4-8be2-cd017d1c3e89.png)

Thanks