### PR TITLE
Adding support for feedback link customization

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -30,6 +30,11 @@ exclude:
 feedback_email: tomjohnson1492@gmail.com
 # used as a contact email for the Feedback link in the top navigation bar
 
+#feedback_disable: true
+#feedback_text: "Need help?"
+#feedback_link: "http://helpy.io/"
+# change feedback link behaviour if you use a support ticketing system or something else
+
 highlighter: rouge
 # library used for syntax highlighting
 

--- a/_includes/feedback.html
+++ b/_includes/feedback.html
@@ -13,4 +13,4 @@ window.location.href = uri;
 }
 </script>
 
-<li><a href="javascript:(function()%7BSendLinkByMail()%3B%7D)()%3B" target="_blank"><i class="fa fa-envelope-o"></i> Feedback</a></li>
+<li><a href="{% if site.feedback_link %}{{site.feedback_link}}{% else %}javascript:(function()%7BSendLinkByMail()%3B%7D)()%3B{% endif %}" target="_blank">{% if site.feedback_link == null %}<i class="fa fa-envelope-o"></i>{% endif %} {% if site.feedback_text %}{{site.feedback_text}}{% else %}Feedback{% endif %}</a></li>

--- a/_includes/topnav.html
+++ b/_includes/topnav.html
@@ -44,7 +44,9 @@
                 </li>
                 {% endfor %}
                 {% endfor %}
-                {% include feedback.html %}
+                {% if site.feedback_disable == null or site.feedback_disable == false %}
+			{% include feedback.html %}
+		{% endif %}
                 <!--comment out this block if you want to hide search-->
                 <li>
                     <!--start search-->


### PR DESCRIPTION
I needed better support for "Feedback" link customization. Now you can either disable it or change text and URL, in case you have an external ticketing system.
