### PR TITLE
Adding support for company_url and company_logo parameters.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,8 @@ topnav_title: Jekyll Documentation Theme
 site_title: Jekyll theme for designers
 # this appears in the html browser tab for the site title (seen mostly by search engines, not users)
 company_name: Your company
+company_url: https://github.com/tomjohnson1492/documentation-theme-jekyll
+#company_logo: http://domain/image.jpg
 # this appears in the footer
 github_editme_path: tomjohnson1492/documentation-theme-jekyll/edit/reviews
 # if you're using Github, provide the basepath to the branch you've created for reviews, following the sample here. if not, leave this value blank.

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,7 +3,7 @@
                 <div class="col-lg-12 footer">
                &copy;{{ site.time | date: "%Y"  }} {{site.company_name}}. All rights reserved. <br />
 {% if page.last_updated %}<p>Page last updated:</span> {{page.last_updated}}<br/>{% endif %} Site last generated: {{ site.time | date: "%b %-d, %Y"  }} <br />
-<p><img src="{{ "/images/company_logo.png" |  prepend: site.baseurl }}" alt="Company logo"/></p>
+<p>{% if site.company_url %}<a href="{{site.company_url}}" target=_blank>{% endif %}<img src="{% if site.company_logo %}{{site.company_logo}}{% else %}{{ "/images/company_logo.png" |  prepend: site.baseurl }}{% endif %}" alt="{{site.company_name}}"/>{% if site.company_url %}</a>{% endif %}</p>
                 </div>
             </div>
 </footer>


### PR DESCRIPTION
Hopefully, we will be submitting a few changes to make this theme more flexible. This way we can use it as a git submodule. I wrote a simple [medium post](https://medium.com/@lafraia/best-practices-installing-jekyll-theme-using-git-submodules-a40a5f7a9edc) explaining this approach.

It's better to configure everything from `_config.yml` :smile: 
