### PR TITLE
unless forloop for comma was missing from site.pages in search.json

### DIFF
--- a/search.json
+++ b/search.json
@@ -13,7 +13,8 @@ search: exclude
 "keywords": "{{page.keywords}}",
 "url": "{{ page.url | remove: "/"}}",
 "summary": "{{page.summary | strip }}"
-},
+}
+{% unless forloop.last and site.posts.size < 1 %},{% endunless %}
 {% endunless %}
 {% endfor %}
 


### PR DESCRIPTION
If the site has only pages this results in invalid json as there will be a trailing comma.