### PR TITLE
Improve feedback link configuration

### DIFF
--- a/_includes/feedback.html
+++ b/_includes/feedback.html
@@ -1,1 +1,13 @@
-<li><a class="email" title="Submit feedback" href="#" onclick="javascript:window.location='mailto:{{site.feedback_email}}?subject={{site.feedback_subject_line}} feedback&body=I have some feedback about the {{page.title}} page: ' + window.location.href;"><i class="fa fa-envelope-o"></i> Feedback</a><li>
+<li>
+{% if site.feedback_text %}
+  {% assign feedback_text = site.feedback_text %}
+{% else %}
+  {% assign feedback_text = "Feedback" %}
+{% endif %}
+
+{% if site.feedback_link %}
+  <a class="email" title="Submit feedback" href="{{site.feedback_link}}">{{feedback_text}}</a>
+{% else %}
+  <a class="email" title="Submit feedback" href="#" onclick="javascript:window.location='mailto:{{site.feedback_email}}?subject={{site.feedback_subject_line}} feedback&body=I have some feedback about the {{page.title}} page: ' + window.location.href;"><i class="fa fa-envelope-o"></i> {{feedback_text}}</a>
+{% endif %}
+<li>


### PR DESCRIPTION
Lines 31-43 of [_config.yml](https://github.com/tomjohnson1492/documentation-theme-jekyll/blob/gh-pages/_config.yml#L31-L43) suggest customising the feedback link is possible, however  only having a link to send an email is possible. This PR changes that.