### PR TITLE
Fix post search

### DIFF
--- a/search.json
+++ b/search.json
@@ -24,7 +24,7 @@ search: exclude
 "title": "{{ post.title | escape }}",
 "tags": "{{ post.tags }}",
 "keywords": "{{post.keywords}}",
-"url": "{{ post.url }}",
+"url": "{{ post.url | remove: "/" }}",
 "summary": "{{post.summary | strip }}"
 }
 {% unless forloop.last %},{% endunless %}


### PR DESCRIPTION
To reproduce the bug:
1. Go to http://idratherbewriting.com/documentation-theme-jekyll/
2. In the search bar, enter "Sample post"
3. Click on the only match -> Got page not found

The fixed version: https://hongchangwu.github.io/documentation-theme-jekyll/index.html
