### PR TITLE
Fix sidebar css so arrows change shape when open

### DIFF
--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -369,7 +369,7 @@ a.accordion-toggle, a.accordion-collapsed {
 .nav li > a > span:after {
     content: '\25be';
 }
-.nav li.open > a > span:after {
+.nav li.active > a > span:after {
     content: '\25b4';
 }
 


### PR DESCRIPTION
The sidebar arrows should change content when they're open.  There's a small bug in css/customstyles.css that prevents this; other parts of the style use 'active' instead of 'open' so it needs to here too.

This PR fixes it.

Since Font Awesome is already wired in, I think that their carets look nicer.  Here's how:

```
.nav li > a > span:after {
   font-family: FontAwesome;
   content: "\f105";

}
.nav li.active > a > span:after {
   font-family: FontAwesome;
   content: "\f107";
}
```