### PR TITLE
Updating Gemfile to enable watching on windows

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
 gem 'github-pages', group: :jekyll_plugins
+gem 'wdm', '>= 0.1.0' if Gem.win_platform?

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,12 +190,14 @@ GEM
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     unicode-display_width (1.1.3)
+    wdm (0.1.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   github-pages
+  wdm (>= 0.1.0)
 
 BUNDLED WITH
    1.14.3


### PR DESCRIPTION
Without wdm gem the watching and auto-generation is broken. This change fixes it.