### PR TITLE
Adding vscode settings file to ignore formatting of liquid files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+  "files.associations": {
+    "*.html": "liquid"
+  }
+}


### PR DESCRIPTION
When using vscode to edit the theme/site, the editor formats the HTML files in a funky way that breaks the site generation. This change tells the editor to treat HTML files as liquid template files, thus disabling the funky formatting on save.

**Please** accept this PR, **please**!

