### PR TITLE
Disqus plugin is not showing up because of a bug in page and post lay…

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -59,9 +59,7 @@ layout: default
         {% endif %}
     </div>
 
-    {% if site.disqus %}
 {% include disqus.html %}
-    {% endif %}
 
 </div>
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -32,9 +32,7 @@ layout: default
 
 </article>
 
-{% if site.disqus %}
 {% include disqus.html %}
-{% endif %}
 
 {{site.data.alerts.hr_shaded}}
 


### PR DESCRIPTION
Because the include file already has the check, we don't need it in the layout pages. Removed it.

