### PR TITLE
Created 'createtag' script to create tag pages.

### DIFF
--- a/createtag
+++ b/createtag
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+# Using a 'cat' here document, create a file for jekyll
+# website containing what's required for tag pages.
+
+# Pass in tag name(s)
+#   ./createtag linux bsd
+
+CMDLINEPARAM=1     #  Takes at least one param.
+TAGDIR="pages/tags"
+
+if [ $# -ge $CMDLINEPARAM ]
+then
+  tags=$@
+else
+  echo "Atleast ${CMDLINEPARAM} tag name is required."
+  exit 1
+fi
+
+if [ -d "${TAGDIR}" ]; then
+
+  echo "Creating tag(s) for ${tags}"
+
+  for tag in ${tags}; do
+  # Cannot indent here string.
+cat <<EOF >"${TAGDIR}/tag_${tag}.md"
+---
+title: "${tag} Posts"
+tagName: ${tag}
+search: exclude
+permalink: tag_${tag}.html
+sidebar: mydoc_sidebar
+hide_sidebar: true
+folder: tags
+---
+
+{% include taglogic.html %}
+
+{% include links.html %}
+EOF
+
+  done
+
+else
+  echo "Directory ${TAGDIR} doesn't exist or you are not in the top-level directory."
+  echo "Please run again from the root directory of your project."
+  exit 1
+fi
+
+exit


### PR DESCRIPTION
A script to automatically create a tag page. Running the script from the root directory of the project will create a tag page in 'pages/tags' for every parameter input into the script and tag_${tag}.md will contain the following.

```
---
title: "${tag} Posts"
tagName: ${tag}
search: exclude
permalink: tag_${tag}.html
sidebar: mydoc_sidebar
hide_sidebar: true
folder: tags
---

{% include taglogic.html %}

{% include links.html %}
```

It should be easy to replace this with altered content if it is unsatisfactory. 

---

I'm not sure if you're interested in it, but if you are let me know if you want any changes.