### PR TITLE
added prompt to choose title, tag is added to allowed-tags

### DIFF
--- a/_data/tags.yml
+++ b/_data/tags.yml
@@ -1,3 +1,6 @@
+# Note:
+# If you are using the createtag script, don't leave an blank line at the end of this file.
+# In other words, the last line must be the last tag in the allowed-tags list.
 allowed-tags:
   - getting_started
   - content_types

--- a/createtag
+++ b/createtag
@@ -22,10 +22,12 @@ if [ -d "${TAGDIR}" ]; then
   echo "Creating tag(s) for ${tags}"
 
   for tag in ${tags}; do
+    echo "Title for $tag:"
+    read title
   # Cannot indent here string.
 cat <<EOF >"${TAGDIR}/tag_${tag}.md"
 ---
-title: "${tag} Posts"
+title: "${title}"
 tagName: ${tag}
 search: exclude
 permalink: tag_${tag}.html
@@ -38,6 +40,8 @@ folder: tags
 
 {% include links.html %}
 EOF
+
+echo "  - ${tag}" >> _data/tags.yml
 
   done
 


### PR DESCRIPTION
I improved the **createtag** script a little bit in order to fully automate the tag management process.
* You are prompted to choose for each tag the title used in the tag page because sometimes you want something less generic than just "${tag} Posts"
* The tags is added to the allowed-tags list. I think that if you are adding a new tag is because you using it somewhere.

Do you find useful these changes?