### PR TITLE
Update Dockerfile. Use Jekyll official image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,11 @@
-FROM ruby:2.1
-MAINTAINER mrafayaleem@gmail.com
-
-RUN apt-get clean \
-  && mv /var/lib/apt/lists /var/lib/apt/lists.broke \
-  && mkdir -p /var/lib/apt/lists/partial
-
-RUN apt-get update
-
-RUN apt-get install -y \
-    node \
-    python-pygments \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/
+FROM jekyll/builder
 
 WORKDIR /tmp
 ADD Gemfile /tmp/
 ADD Gemfile.lock /tmp/
 RUN bundle install
+
+FROM jekyll/jekyll
 
 VOLUME /src
 EXPOSE 4000


### PR DESCRIPTION
The other docker file was giving me an error described here

https://github.com/jekyll/jekyll/issues/4268

I updated the docker file to use the official jekyll images in a multi build docker file.