### PR TITLE
Update of jquery and anchor js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ _site/
 _pdf
 .DS_Store
 .idea
+vendor/
+.bundle/

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,7 @@
 source "https://rubygems.org"
 
+# to publish on github page
 gem 'github-pages', group: :jekyll_plugins
+
+# to publich without github page
+#gem "jekyll"

--- a/_config.yml
+++ b/_config.yml
@@ -33,6 +33,7 @@ port: 4000
 exclude:
   - .idea/
   - .gitignore
+  - vendor
 # these are the files and directories that jekyll will exclude from the build
 
 feedback_subject_line: Jekyll documentation theme

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -16,7 +16,7 @@
 <!-- most color styles are extracted out to here -->
 <link rel="stylesheet" href="css/theme-blue.css">
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-cookie/1.4.1/jquery.cookie.min.js"></script>
 <script src="{{ "js/jquery.navgoco.min.js" }}"></script>
@@ -25,7 +25,7 @@
 <!-- Latest compiled and minified JavaScript -->
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 <!-- Anchor.js -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/2.0.0/anchor.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/4.2.0/anchor.min.js"></script>
 <script src="{{ "js/toc.js" }}"></script>
 <script src="{{ "js/customscripts.js" }}"></script>
 


### PR DESCRIPTION
I update the version of the two libraries and I had a comment line in the gemfile to build without the github page gems. 
[https://idratherbewriting.com/documentation-theme-jekyll/index.html#option1](https://idratherbewriting.com/documentation-theme-jekyll/index.html#option1 )
File .gitignore and _config.yml modified to exclude the directories that bundle creates.