### PR TITLE
mydoc_pages.md: add Visual Studio Code

### DIFF
--- a/pages/mydoc/mydoc_pages.md
+++ b/pages/mydoc/mydoc_pages.md
@@ -10,7 +10,7 @@ folder: mydoc
 ---
 
 ## Where to author content
-Use a text editor such as Sublime Text, WebStorm, IntelliJ, or Atom to create pages. Atom is recommended because it's created by Github, which is driving some of the Jekyll development through Github Pages.
+Use a text editor such as Sublime Text, WebStorm, IntelliJ, Visual Studio Code or Atom to create pages. Atom is recommended because it's created by Github, which is driving some of the Jekyll development through Github Pages.
 
 ## Where to save pages
 


### PR DESCRIPTION
add Visual Studio Code since it is the most used and most widely spread text editor, even more than Atom.
By the way GitHub was bought by Microsoft, VSCode is developed by Microsoft and Atom is developed by GitHub so by Microsoft too.