### PR TITLE
Make focus style visible in nav for keyboard navigation

### DIFF
--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -336,7 +336,6 @@ a.accordion-toggle, a.accordion-collapsed {
 .nav a {
     color: #333;
     display: block;
-    outline: none;
     /*-webkit-border-radius: 4px;
     -moz-border-radius: 4px;
     border-radius: 4px;*/
@@ -536,6 +535,10 @@ button.cursorNorm {
 
 a.dropdown-toggle, .navbar-inverse .navbar-nav > li > a  {
     margin-left: 10px;
+}
+
+.navbar a:focus {
+    outline: 1px solid #fff;
 }
 
 hr.faded {


### PR DESCRIPTION
Hello, thank you for making such a fully featured theme available! One accessibility issue I noticed that that it is hard to use [keyboard navigation](https://webaim.org/techniques/keyboard/) with this theme because it's not clear when a nav element is in focus. I am submitting a couple of small CSS changes that help with focus styling, including removing the `outline: 0` styling from other nav elements as well ([more info here](www.outlinenone.com)).

Looking forward to your thoughts on this and thanks again for providing this theme.

Example of navbar item ("News") with focus styling

![Screen Shot 2019-10-27 at 12 28 03 PM](https://user-images.githubusercontent.com/7991694/67638179-3d710a00-f8b8-11e9-8546-7d625403e85c.png)

Example of nav item that has focus ("Supported features") and doesn't have its default browser styling removed from `outline: 0`

![Screen Shot 2019-10-27 at 12 28 27 PM](https://user-images.githubusercontent.com/7991694/67638196-4a8df900-f8b8-11e9-8f40-c3c959d2835d.png)
