### PR TITLE
Error in the searcher when pages are excluded from the search

### DIFF
--- a/search.json
+++ b/search.json
@@ -4,9 +4,9 @@ layout: none
 search: exclude
 ---
 
+{% assign pages = site.html_pages | where_exp: "page", "page.search != 'exclude'"  %}
 [
-{% for page in site.html_pages %}
-{% unless page.search == "exclude" %}
+{% for page in pages %}
 {
 "title": "{{ page.title | escape }}",
 "tags": "{{ page.tags }}",
@@ -15,7 +15,6 @@ search: exclude
 "summary": "{{page.summary | strip }}"
 }
 {% unless forloop.last and site.posts.size < 1 %},{% endunless %}
-{% endunless %}
 {% endfor %}
 
 {% for post in site.posts %}


### PR DESCRIPTION
The cause of this error is in the search.json file. The error occurs when the last page (pages are sorted alphabetically) of site.html_pages has the parameter search: "exclude" and no posts exist. This results in an extra comma. This extra comma causes the json to be incorrectly formatted.

This error can be solved by filtering those pages that are excluded from the search (search: "exclude"). This way, the for loop will only iterate over the pages included in the search and there will be no extra commas.

Closes #221 